### PR TITLE
Fix compiler warnings and the bugs they point to

### DIFF
--- a/src/Store/BStore.cpp
+++ b/src/Store/BStore.cpp
@@ -746,7 +746,7 @@ bool BStore::Serialise(BinaryStream &bs){ // do return properly
   bs & output;
   bs & m_lookup;
   GetEntry(0);
-  /*
+#if 0
   save;
 
   if(bs.m_write){
@@ -761,9 +761,9 @@ bool BStore::Serialise(BinaryStream &bs){ // do return properly
     close
       open
       }
-  */
+#endif
 
-  /* 
+#if 0
   bs & m_lookup;
 
   
@@ -789,7 +789,7 @@ bool BStore::Serialise(BinaryStream &bs){ // do return properly
 
   if(!GetHeader()) return false;
   if(!GetEntry(0)) return false;
-  */
+#endif
 
 
 
@@ -801,7 +801,7 @@ bool BStore::Serialise(BinaryStream &bs){ // do return properly
   /////
 
 
-  /*   // uncomment here to start
+#if 0   // uncomment here to start
   //writing 
   if(bs.m_write){
     if(not ram){
@@ -856,7 +856,7 @@ bool BStore::Serialise(BinaryStream &bs){ // do return properly
   }
 
 
- /*
+#if 0
    //std::cout<<"p1"<<std::endl;
     if(!(bs & m_variables)) return false;
     //std::cout<<"p2"<<std::endl;
@@ -872,7 +872,8 @@ bool BStore::Serialise(BinaryStream &bs){ // do return properly
     //std::cout<<"p6"<<std::endl;
     if(!(bs & m_lookup)) return false;
     //std::cout<<"p7"<<std::endl;
-    */
+#endif
+#endif
 
     return true;
     

--- a/src/Store/BinaryStream.h
+++ b/src/Store/BinaryStream.h
@@ -22,6 +22,25 @@ enum enum_endpoint { RAM , UNCOMPRESSED , POST_PRE_COMPRESS, COMPRESSED };
 enum enum_mode { READ , NEW , APPEND, UPDATE, READ_APPEND, NEW_READ };
 
 class BinaryStream : public SerialisableObject{ 
+ private:
+  // Equivalent to std::is_baseof<Derived, Base> in C++11
+  template<typename Derived, typename Base>
+  class is_base_of {
+    private:
+      static short check(const Base*);
+      static char  check(...);
+    public:
+      static const bool value
+	= sizeof(check(static_cast<const Derived*>(0))) == sizeof(short);
+  };
+
+  // Equivalent to std::enable_if<B, T> in C++11
+  template <bool B, typename T = void> struct enable_if {};
+
+  template <typename T>
+  struct enable_if<true, T> {
+    typedef T type;
+  };
   
  public:
   
@@ -56,15 +75,45 @@ class BinaryStream : public SerialisableObject{
 
   //operator overloads
 
-  bool operator<<(std::string& rhs) {
+  template <typename T> bool operator&(const T& rhs) {
+    if (!m_write) return false;
+    return *this << rhs;
+  }
+
+  template <typename T> bool operator&(T& rhs) {
+    if (m_write) return *this << rhs;
+    return *this >> rhs;
+  }
+
+  template <typename T>
+  typename enable_if<is_base_of<T, SerialisableObject>::value, bool>::type
+  operator<<(T& rhs) {
     if (m_mode == READ) return false;
+    m_write = true;
+    return rhs.SerialiseWrapper(*this);
+  }
 
-    unsigned int len = rhs.length();
-    if (!(*this << len)) return false;
+  template <typename T>
+  typename enable_if<is_base_of<T, SerialisableObject>::value, bool>::type
+  operator>>(T& rhs) {
+    if (m_mode == NEW || m_mode == APPEND) return false;
+    m_write = false;
+    return rhs.SerialiseWrapper(*this);
+  }
 
-    if (len == 0) return true;
-    return Bwrite(rhs.data(), len);
-  };
+  template <typename T>
+  typename enable_if<!is_base_of<T, SerialisableObject>::value, bool>::type
+  operator<<(const T& rhs) {
+    if (m_mode == READ) return false;
+    return Bwrite(&rhs, sizeof(T));
+  }
+
+  template <typename T>
+  typename enable_if<!is_base_of<T, SerialisableObject>::value, bool>::type
+  operator>>(T& rhs) {
+    if (m_mode == NEW || m_mode == APPEND) return false;
+    return Bread(&rhs, sizeof(T));
+  }
 
   bool operator<<(const std::string& rhs) {
     if (m_mode == READ) return false;
@@ -74,7 +123,7 @@ class BinaryStream : public SerialisableObject{
 
     if (len == 0) return true;
     return Bwrite(rhs.data(), len);
-  };
+  }
 
   bool operator>>(std::string& rhs) {
     if (m_mode == NEW || m_mode == APPEND) return false;
@@ -85,149 +134,71 @@ class BinaryStream : public SerialisableObject{
     rhs.resize(len);
     if (len == 0) return true;
     return Bread(rhs.data(), len);
+  }
+
+  template <typename T>
+  typename enable_if<is_base_of<T, SerialisableObject>::value, bool>::type
+  operator<<(std::vector<T>& rhs) {
+    return serialise_container(rhs);
+  }
+
+  template <typename T>
+  typename enable_if<is_base_of<T, SerialisableObject>::value, bool>::type
+  operator>>(std::vector<T>& rhs) {
+    return deserialise_container(rhs);
+  }
+
+  template <typename T>
+  typename enable_if<!is_base_of<T, SerialisableObject>::value, bool>::type
+  operator<<(const std::vector<T>& rhs) {
+    if (m_mode == READ) return false;
+
+    unsigned int size = rhs.size();
+    if (!(*this << size)) return false;
+
+    if (size == 0) return true;
+    return Bwrite(rhs.data(), size * sizeof(T));
+  }
+
+  template <typename T>
+  typename enable_if<!is_base_of<T, SerialisableObject>::value, bool>::type
+  operator>>(std::vector<T>& rhs) {
+    if (m_mode == NEW || m_mode == APPEND) return false;
+
+    unsigned int size = 0;
+    if (!(*this >> size)) return false;
+
+    rhs.resize(size);
+    if (size == 0) return true;
+    return Bread(rhs.data(), size * sizeof(T));
+  }
+
+  bool operator<<(const std::vector<std::string>& rhs) {
+    return serialise_container(rhs);
   };
 
-  bool operator&(std::string& rhs){
-    if(m_write) return (*this) << rhs;
-    else return (*this) >> rhs;
-  }
-
-  bool operator&(const std::string& rhs){
-    if(m_write) return (*this) << rhs;
-    return false;
-  }
-
- 
-  template<typename T> bool operator<<(T& rhs){
-     if(m_mode!=READ){
-      if(check_base<SerialisableObject,T>::value){
-	SerialisableObject* tmp=reinterpret_cast<SerialisableObject*>(&rhs);
-	m_write=true;
-	return tmp->SerialiseWrapper(*this);
-      }
-      else return Bwrite(&rhs, sizeof(T));
-    }
-    else return false;
-  }
-
-  
-  template<typename T> bool operator>>(T& rhs){
-    if(m_mode!=NEW && m_mode!=APPEND){
-      if(check_base<SerialisableObject,T>::value){
-	SerialisableObject* tmp=reinterpret_cast<SerialisableObject*>(&rhs);
-	m_write=false;
-	return tmp->SerialiseWrapper(*this);
-      }
-      else return Bread(&rhs, sizeof(T)); 
-    }
-    return false;
-  }
-  
-  
-  template<typename T> bool operator&(T& rhs){
-    if(m_write)  return (*this) << rhs;
-    else return (*this) >> rhs; 
-  }
-  
-  template<typename T> bool operator<<(const T& rhs){
-    if(m_mode!=READ){
-      if(check_base<SerialisableObject,T>::value){
-	SerialisableObject* tmp=reinterpret_cast<SerialisableObject*>(&rhs);
-	m_write=true;
-	return tmp->SerialiseWrapper(*this);
-      }
-      return Bwrite(&rhs, sizeof(T));
-    }
-    else return false;
-  }
-  
-  template<typename T> bool operator&(const T& rhs){
-    if(m_write) return (*this) << rhs;
-    return false;
-  }
-  
-  template<typename T> bool operator<<(std::vector<T>& rhs) {
-    if (m_mode == READ) return false;
-
-    unsigned int size = rhs.size();
-    if (!(*this << size)) return false;
-
-    if (size == 0) return true;
-
-    if (!check_base<SerialisableObject, T>::value)
-      return Bwrite(rhs.data(), size * sizeof(T));
-
-    for (typename std::vector<T>::iterator it = rhs.begin(); it != rhs.end(); ++it)
-      if (!(*this << *it)) return false;
-    return true;
-  }
-
-  template<typename T> bool operator>>(std::vector<T>& rhs) {
-    if (m_mode == NEW || m_mode == APPEND) return false;
-
-    unsigned int size = 0;
-    if (!(*this >> size)) return false;
-
-    rhs.resize(size);
-    if (size == 0) return true;
-
-    if (!check_base<SerialisableObject, T>::value)
-      return Bread(rhs.data(), size * sizeof(T));
-
-    for (typename std::vector<T>::iterator it = rhs.begin(); it != rhs.end(); ++it)
-      if (!(*this >> *it)) return false;
-    return true;
-  }
-  
-  template<typename T> bool operator&(std::vector<T>& rhs){
-    
-    if(m_write) return (*this) << rhs;
-    else return (*this) >> rhs;
-  }
-
-  bool operator<<(std::vector<std::string>& rhs) {
-    if (m_mode == READ) return false;
-
-    unsigned int size = rhs.size();
-    if (!(*this << size)) return false;
-
-    for (unsigned int i = 0; i < size; ++i)
-      if (!(*this << rhs[i])) return false;
-    return true;
-  }
-
   bool operator>>(std::vector<std::string>& rhs) {
-    if (m_mode == NEW || m_mode == APPEND) return false;
+    return deserialise_container(rhs);
+  };
 
-    unsigned int size = 0;
-    if (!(*this >> size)) return false;
-
-    rhs.resize(size);
-    for (unsigned int i = 0; i < size; ++i)
-      if (!(*this >> rhs[i])) return false;
-    return true;
-  }
-  
-  bool operator&(std::vector<std::string>& rhs){   
-    if(m_write) return (*this) << rhs;
-    else return (*this) >> rhs;
-  }
-
-  template<typename T, typename U> bool operator<<(std::map<T, U>& rhs) {
+  template <typename First, typename Second>
+  bool operator<<(std::pair<First, Second>& rhs) {
     if (m_mode == READ) return false;
-
-    unsigned int size = rhs.size();
-    if (!(*this << size)) return false;
-
-    for (typename std::map<T, U>::iterator it = rhs.begin(); it != rhs.end(); ++it) {
-      T key = it->first;
-      U value = it->second;
-      if (!(*this << key && *this << value)) return false;
-    }
-    return true;
+    return *this << rhs.first && *this << rhs.second;
   }
 
-  template<typename T, typename U> bool operator>>(std::map<T, U>& rhs) {
+  template <typename First, typename Second>
+  bool operator>>(std::pair<First, Second>& rhs) {
+    if (m_mode == NEW || m_mode == APPEND) return false;
+    return *this >> rhs.first && *this >> rhs.second;
+  }
+
+  template <typename T, typename U> bool operator<<(std::map<T, U>& rhs) {
+    return serialise_container(rhs);
+  }
+
+  template <typename T, typename U> bool operator>>(std::map<T, U>& rhs) {
+    // std::map has no resize, so we cannot use deserialise_container
     if (m_mode == NEW || m_mode == APPEND) return false;
 
     unsigned int size = 0;
@@ -241,130 +212,53 @@ class BinaryStream : public SerialisableObject{
     };
     return true;
   }
-  
-  template<typename T, typename U> bool operator&(std::map<T,U>& rhs){
-    if(m_write) return (*this) << rhs;
-    else return (*this) >> rhs;
-  } 
 
-  template<typename T> bool operator<<(std::deque<T>& rhs) {
-    if (m_mode == READ) return false;
-
-    unsigned int size = rhs.size();
-    if (!(*this << size)) return false;
-
-    if (size == 0) return true;
-
-    for (typename std::deque<T>::iterator it = rhs.begin();
-	 it != rhs.end();
-	 ++it)
-      if (check_base<SerialisableObject, T>::value) {
-	if (!(*this << *it))
-	  return false;
-      } else if (!Bwrite(&*it, sizeof(T)))
-	return false;
-    return true;
+  template <typename T> bool operator<<(std::deque<T>& rhs) {
+    return serialise_container(rhs);
   }
 
-  template<typename T> bool operator>>(std::deque<T>& rhs) {
-    if (m_mode == NEW || m_mode == APPEND) return false;
-
-    unsigned int size = 0;
-    if (!(*this >> size)) return false;
-
-    rhs.resize(size);
-    if (size == 0) return true;
-
-    for (typename std::deque<T>::iterator it = rhs.begin();
-	 it != rhs.end();
-	 ++it)
-      if (check_base<SerialisableObject, T>::value) {
-	if (!(*this >> *it))
-	  return false;
-      } else if (!Bread(&*it, sizeof(T)))
-	return false;
-    return true;
+  template <typename T> bool operator>>(std::deque<T>& rhs) {
+    return deserialise_container(rhs);
   }
 
-  template<typename T> bool operator&(std::deque<T>& rhs){
-    if(m_write) return(*this) << rhs;
-    else return(*this) >> rhs;    
-  }
-
-  bool operator<<(std::deque<std::string>& rhs) {
-    if (m_mode == READ) return false;
-
-    unsigned int len = rhs.size();
-    if (!(*this << len)) return false;
-
-    for (unsigned int i = 0; i < len; ++i)
-      if (!(*this << rhs[i])) return false;
-    return true;
-  };
-
-  bool operator>>(std::deque<std::string>& rhs) {
-    if (m_mode == NEW || m_mode == APPEND) return false;
-
-    unsigned int size = 0;
-    if (!(*this >> size)) return false;
-
-    rhs.resize(size);
-    for (unsigned int i = 0; i < size; ++i)
-      if (!(*this >> rhs[i])) return false;
-    return true;
-  };
-  
-  bool operator&(std::deque<std::string>& rhs){
-    if(m_write) return (*this) << rhs;
-    else return (*this) >> rhs;    
-  }     
-  
-  
  private:
 
   int def(FILE *source, FILE *dest, int level);
   int inf(FILE *source, FILE *dest);
   void zerr(int ret);
-  
-  template <typename B, typename D> struct Host{
-    
-    operator B*() const;
-    operator D*();
-    
-  };
-  
- 
-  template <typename B, typename D> struct check_base {
-    template <typename T> 
-    static short check(D*, T);
-    static char check(B*, int);
-    
-    static const bool value = sizeof(check(Host<B,D>(), int())) == sizeof(short);
-  };
 
-  /*
-derived:
+  template <typename Container>
+  bool serialise_container(const Container& container) {
+    if (m_mode == READ) return false;
 
-  yes D*(Host<B,D>(),T)   = D*(B* const, T);  not allowed
-                          = D*(D*, T); ----------------------------------------------------------------------------------->   preferred as D*->D* better than D*->B* : answer yes
+    unsigned int size = container.size();
+    if (!(*this << size)) return false;
 
-  no B*(Host<B,D>(), int) =  B*(B* const, int); 
-                          =  B*(D*, int);  preferred as not const and object called on is not const----------------------->
+    if (size == 0) return true;
 
+    for (typename Container::const_iterator i = container.begin();
+	 i != container.end();
+	 ++i)
+      if (!(*this << *i)) return false;
+    return true;
+  }
 
-not derrived:
+  template <typename Container>
+  bool deserialise_container(Container& container) {
+    if (m_mode == NEW || m_mode == APPEND) return false;
 
-  yes D*(Host<B,D>(),T)   =  D*(B* const, T); not allowed
-                          =  D*(D*, T); ------------------------------>
+    unsigned int size = 0;
+    if (!(*this >> size)) return false;
 
-  no B*(Host<B,D>(), int) =  B*(B* const, int);----------------------->  preffered as not templated : answer no
-                          =  B*(D*, int); not allowed
+    if (size == 0) return true;
 
-
-   */
-
-
+    container.resize(size);
+    for (typename Container::iterator i = container.begin();
+	 i != container.end();
+	 ++i)
+      if (!(*this >> *i)) return false;
+    return true;
+  }
 };
-
 
 #endif

--- a/src/Store/BinaryStream.h
+++ b/src/Store/BinaryStream.h
@@ -267,10 +267,11 @@ class BinaryStream : public SerialisableObject{
       unsigned int tmp=rhs.size(); 
       ret*=(*this) << tmp;
       if(tmp){
-	if(check_base<SerialisableObject,T>::value){
-	  for(typename std::deque<T>::iterator it=rhs.begin(); it!=rhs.end(); it++) ret*=(*this) << (*it);	
-	}
-	else ret*=Bwrite(&(rhs[0]), tmp*sizeof(T));
+	for(typename std::deque<T>::iterator it=rhs.begin(); it!=rhs.end(); it++)
+	  if(check_base<SerialisableObject,T>::value)
+	    ret*=(*this) << (*it);
+	  else
+	    ret*=Bwrite(&*it, sizeof(T));
       }
       return ret;
     }
@@ -284,10 +285,11 @@ class BinaryStream : public SerialisableObject{
       ret*=(*this) >> tmp;
       rhs.resize(tmp);
       if(tmp){
-	if(check_base<SerialisableObject,T>::value){
-	  for(typename std::deque<T>::iterator it=rhs.begin(); it!=rhs.end(); it++) ret*=(*this) >> (*it);
-	}
-	else ret*=Bread(&(rhs[0]), tmp*sizeof(T));
+	for(typename std::deque<T>::iterator it=rhs.begin(); it!=rhs.end(); it++)
+	  if(check_base<SerialisableObject,T>::value)
+	    ret*=(*this) >> (*it);
+	  else
+	    ret*=Bread(&*it, sizeof(T));
       }
       return ret;
     }

--- a/src/Store/SerialisableObject.h
+++ b/src/Store/SerialisableObject.h
@@ -20,6 +20,8 @@ class SerialisableObject{
   
  public:
 
+  virtual ~SerialisableObject() {};
+
   bool SerialiseWrapper(BinaryStream &bs);
   virtual bool Serialise(BinaryStream &bs)=0;
   virtual std::string GetVersion()=0;


### PR DESCRIPTION
The biggest change here is the redesign of BinaryStream API. One possibly backwards incompatible change is that `BinaryStream::operator<<` and `BinaryStream::operator>>` now short-circuit on failure. Previously when (de-)serializing a container, e.g., std::vector, the operator would attempt to (de-)serialize all its items, and then check for the error. Now it stops and returns false as soon as an error occurs. In both cases if the container was partially (de-)serialized, the stream is left in inconsistent state, so nobody should have relied on this behaviour.

Another change is that when serializing a container, BinaryStream now checks its mode (READ, NEW or APPEND) only once. I assume that the mode cannot change during serialization.

Also, `BinaryStream::operator<<` emitted compile errors when being passed a const reference to, e.g., `std::vector<int>`. I cleaned up the template magic to make it work, see the usage of `is_base_of` and `enable_if`.

While working on BinaryStream API, I noticed that std::deque are serialized in a way that would only work for a small std::deque. The size is implementation-dependendant, and apperently for gcc it is 512 bytes. I fixed that.

Other changes address compiler warnings.