### PR TITLE
Logging::operator<<: change argument type from T& to const T&

### DIFF
--- a/src/Logging/Logging.h
+++ b/src/Logging/Logging.h
@@ -189,7 +189,7 @@ class Logging: virtual public std::ostream {
    return *this;
  }
  
- template<typename T>  Logging& operator<<(T &a){
+ template<typename T>  Logging& operator<<(const T &a){
      
    std::cout.rdbuf(buffer);
    std::cout<<a;


### PR DESCRIPTION
Non-const references cannot be bound to functions results and literals, so the code
```C++
Logging log;
try {
  throw std::runtime_error("message");
} catch (std::exception& e) {
  log << e.what() << '\n';
}
```
ends up calling `std::ostream::operator<<` both for `e.what()` and `'\n'` and produces nothing in the output.