### PR TITLE
WorkerPoolManager: do not set args->job->m_in_progress when the job has been deleted

### DIFF
--- a/src/DataModelBase/WorkerPoolManager.cpp
+++ b/src/DataModelBase/WorkerPoolManager.cpp
@@ -105,12 +105,13 @@ void WorkerPoolManager::WorkerThread(Thread_args* arg) {
     catch(...){
       args->job->m_failed=true;
     }
-    if(args->job_out_deque) args->job_out_deque->push_back(args->job);
-    else{
-      //delete args->job;
-      //args->job=0;
+    if (args->job_out_deque) {
+      args->job_out_deque->push_back(args->job);
+      args->job->m_in_progress=false;
+    } else {
+      delete args->job;
+      args->job=0;
     }
-    args->job->m_in_progress=false;
     args->busy = false;   
   }
   


### PR DESCRIPTION
Do not set args->job->m_in_progress when the job has been deleted