### PR TITLE
Fix storing of a BStore in a BStore and implement JSON encoders

### DIFF
--- a/src/Store/BStore.cpp
+++ b/src/Store/BStore.cpp
@@ -801,7 +801,10 @@ bool BStore::Serialise(BinaryStream &bs){ // do return properly
 
   bs & output;
   bs & m_lookup;
-  GetEntry(0);
+  bs & m_variables;
+  bs & m_type_checking;
+  if (m_type_checking) bs & m_type_info;
+
   /*
   save;
 

--- a/src/Store/BStore.cpp
+++ b/src/Store/BStore.cpp
@@ -48,22 +48,23 @@ BStore::BStore(const BStore &bs):m_version(1.0){
    
    if(bs.Header){
      Header = new BStore(*bs.Header);
-   }
+   } else
+     Header = nullptr;
    
    m_lookup = bs.m_lookup;
    output = bs.output;
-   m_file_end = m_file_end;
-   m_file_name = m_file_name;
-   m_open_file_end = m_open_file_end;
-   m_previous_file_end = m_previous_file_end;
-   m_type = m_type;
-   m_type_checking = m_type_checking;
-   m_has_header = m_has_header;
-   m_header_start = m_header_start;
-   m_flags_start = m_flags_start;
-   m_lookup_start = m_lookup_start;
-   m_update = m_update;  
-   m_version = m_version;
+   m_file_end = bs.m_file_end;
+   m_file_name = bs.m_file_name;
+   m_open_file_end = bs.m_open_file_end;
+   m_previous_file_end = bs.m_previous_file_end;
+   m_type = bs.m_type;
+   m_type_checking = bs.m_type_checking;
+   m_has_header = bs.m_has_header;
+   m_header_start = bs.m_header_start;
+   m_flags_start = bs.m_flags_start;
+   m_lookup_start = bs.m_lookup_start;
+   m_update = bs.m_update;
+   m_version = bs.m_version;
    
 }
 

--- a/src/Store/BStore.h
+++ b/src/Store/BStore.h
@@ -14,6 +14,7 @@
 #include <PointerWrapper.h>
 
 #include <BinaryStream.h>
+#include <Json.h>
 #include <sys/stat.h>
 
 namespace ToolFramework{
@@ -71,6 +72,10 @@ namespace ToolFramework{
     /////////importing
     
     void JsonParser(std::string input); ///< Converts a flat JSON formatted string to Store entries in the form of key value pairs.  @param input The input flat JSON string. 
+    bool JsonEncode(std::ostream& output) const; ///< Prints contents as a JSON object if possible
+    bool JsonEncode(std::string& output) const; ///< Prints contents as a JSON objec if possible
+    bool JsonEncode(const std::string& key, std::ostream& output) const; ///< Prints contents of the given key as a JSON if possible.
+    bool JsonEncode(const std::string& key, std::string& output) const; ///< Prints contents of the given key as JSON if possible.
     bool Print();
     void Print(bool values); ///< Prints the contents of the BoostStore. @param values If true values and keys are printed. If false just keys are printed
     void Delete(); ///< Deletes all entries in the BoostStore.
@@ -78,6 +83,7 @@ namespace ToolFramework{
     std::string Type(std::string key); ///< Queries the type of an entry if type checking is turned on. @param key The key of the entry to check. @return A string encoding the type info.
     bool Has(std::string key); ///< Queries if entry exists in a BoostStore. @param key is the key of the varaible to look up. @return true if varaible is present in the store, false if not. 
     //  BoostStore *Header; ///< Pointer to header BoostStore (only available in multi event BoostStore). This can be used to access and assign header varaibles jsut like a standard non multi event store.
+    bool TypeChecking() const { return m_type_checking; }; ///< Whether type checking is enabled (required for JSON serialisation)
     
     /**
        Templated getter function for BoostStore content. Assignment is templated and via reference.
@@ -248,9 +254,11 @@ namespace ToolFramework{
     //int m_file_type; //0=gzopen, 1=fopen, 2=stringstream
     float m_version;
     
+    bool (*GetJsonEncoder(const std::string& key) const)(std::ostream&, const BinaryStream&);
     
   };
 
+  bool json_encode(std::ostream&, const BStore&);
 }
 
 #endif

--- a/src/Store/Json.cpp
+++ b/src/Store/Json.cpp
@@ -1,0 +1,15 @@
+#include <Json.h>
+
+namespace ToolFramework {
+
+bool json_encode(std::ostream& output, const std::string& datum) {
+  output << '"';
+  for (char c : datum) {
+    if (c == '"' || c == '\\') output << '\\';
+    output << c;
+  };
+  output << '"';
+  return true;
+}
+
+}

--- a/src/Store/Json.h
+++ b/src/Store/Json.h
@@ -1,0 +1,64 @@
+#ifndef TOOLFRAMEWORK_JSON_H
+#define TOOLFRAMEWORK_JSON_H
+
+#include <map>
+#include <ostream>
+#include <sstream>
+#include <string>
+#include <type_traits>
+#include <vector>
+
+namespace ToolFramework {
+
+template <typename T>
+typename std::enable_if<std::is_arithmetic<T>::value, bool>::type
+json_encode(std::ostream& output, T datum) {
+  output << datum;
+  return true;
+}
+
+bool json_encode(std::ostream& output, const std::string& datum);
+
+template <typename T>
+bool json_encode(std::ostream& output, const std::vector<T>& data) {
+  output << '[';
+  bool comma = false;
+  for (const T& datum : data) {
+    if (comma)
+      output << ',';
+    else
+      comma = true;
+    json_encode(output, datum);
+  };
+  output << ']';
+  return true;
+}
+
+template <typename T>
+bool json_encode(std::ostream& output, const std::map<std::string, T>& data) {
+  output << '{';
+  bool comma = false;
+  for (auto& datum : data) {
+    if (comma)
+      output << ',';
+    else
+      comma = true;
+    json_encode(output, datum.first);
+    output << ':';
+    json_encode(output, datum.second);
+  };
+  output << '}';
+  return true;
+}
+
+template <typename T>
+bool json_encode(std::string& output, T data) {
+  std::stringstream ss;
+  if (!json_encode(ss, data)) return false;
+  output = ss.str();
+  return true;
+}
+
+}
+
+#endif


### PR DESCRIPTION
Fix bugs related to when a BStore stores another BStore as one of the values. Together with other changes introduced earlier this should make it possible to use BStore to represent JSON objects.

Implement JSON encoders for BStore and other C++ objects such as integral types, string, vector, map.

Note that type checking is required for serialization of BStore contents to JSON.