### PR TITLE
Add files in lib/, include/, and ./main to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 *~
 *.o
+lib/*.so
+include/*.h
+main


### PR DESCRIPTION
This significantly improves the printout of `git status`, and will help to reduce future `git add` errors