### PR TITLE
Add virtual destructor to DataModelBase, such that derived classes wi…

### DIFF
--- a/src/DataModelBase/DataModelBase.h
+++ b/src/DataModelBase/DataModelBase.h
@@ -30,7 +30,9 @@ namespace ToolFramework{
     
   public:
     
-    DataModelBase(); ///< Simple constructor 
+    DataModelBase(); ///< Simple constructor
+
+    virtual ~DataModelBase() = default; ///< Simple destructor
     
     Logging *Log; ///< Log class pointer for use in Tools, it can be used to send messages which can have multiple error levels and destination end points
     


### PR DESCRIPTION
…ll have their destructor called

This is required by any application that has a DataModel that needs to clean up after itself, otherwise only the DataModelBase destructor is called in the ToolChain destructor

This is biting in TriggerApp now