### PR TITLE
Tool: make v_error, v_warning, v_message, v_debug public

### DIFF
--- a/src/Tool/Tool.h
+++ b/src/Tool/Tool.h
@@ -59,13 +59,13 @@ namespace ToolFramework{
       reinterpret_cast<DataModelBase*>(m_data)->vars.Set(m_tool_name,vars_json);
     }
     
-  private:
 
   static const int v_error=0;
   static const int v_warning=1;
   static const int v_message=2;
   static const int v_debug=3;
     
+  private:
     
     
     


### PR DESCRIPTION
This change was made to ButtonDAQ Dependencies during the collaboration meeting