### PR TITLE
add m_configfile to Tool

### DIFF
--- a/src/Tool/Tool.h
+++ b/src/Tool/Tool.h
@@ -60,7 +60,8 @@ namespace ToolFramework{
     }
     
   private:
-
+  
+  std::string m_configfile;
   static const int v_error=0;
   static const int v_warning=1;
   static const int v_message=2;


### PR DESCRIPTION
since m_variables is now populated by an InitialiseConfiguration method that may be called in more places than just Initialise, in order to propagate local config file changes we need to retain the local config file for future calls.
Add a member variable m_configfile to store it in Initialise.