### PR TITLE
Tool: remove static constants setting logging verbosity

### DIFF
--- a/src/Tool/Tool.h
+++ b/src/Tool/Tool.h
@@ -61,14 +61,6 @@ namespace ToolFramework{
     
   private:
 
-  static const int v_error=0;
-  static const int v_warning=1;
-  static const int v_message=2;
-  static const int v_debug=3;
-    
-    
-    
-    
   };
   
 }


### PR DESCRIPTION
Delete v_error, v_warning, v_message, v_debug: use global variables declared in ToolFramework namespace in Logging.h instead. Client code shouldn't be affected.