### PR TITLE
Json updates

### DIFF
--- a/src/Store/Json.cpp
+++ b/src/Store/Json.cpp
@@ -2,14 +2,18 @@
 
 namespace ToolFramework {
 
-bool json_encode(std::ostream& output, const std::string& datum) {
+bool json_encode(std::ostream& output, const char* datum) {
   output << '"';
-  for (char c : datum) {
-    if (c == '"' || c == '\\') output << '\\';
-    output << c;
+  while (*datum) {
+    if (*datum == '"' || *datum == '\\') output << '\\';
+    output << *datum;
   };
   output << '"';
   return true;
-}
+};
+
+bool json_encode(std::ostream& output, const std::string& datum) {
+  return json_encode(output, datum.c_str());
+};
 
 }

--- a/src/Store/Json.h
+++ b/src/Store/Json.h
@@ -10,6 +10,15 @@
 
 namespace ToolFramework {
 
+template <typename T, size_t N>
+bool json_encode(std::ostream&, const std::array<T, N>&);
+
+template <typename T>
+bool json_encode(std::ostream&, const std::vector<T>&);
+
+template <typename T>
+bool json_encode(std::ostream&, const std::map<std::string, T>&);
+
 template <typename T>
 typename std::enable_if<std::is_arithmetic<T>::value, bool>::type
 json_encode(std::ostream& output, T datum) {
@@ -21,19 +30,28 @@ bool json_encode(std::ostream& output, const char* datum);
 bool json_encode(std::ostream& output, const std::string& datum);
 
 template <typename T>
-bool json_encode(std::ostream& output, const std::vector<T>& data) {
+bool json_encode(std::ostream& output, const T* data, size_t size) {
   output << '[';
   bool comma = false;
-  for (const T& datum : data) {
+  for (size_t i = 0; i < size; ++i) {
     if (comma)
       output << ',';
-    else
-      comma = true;
-    if (!json_encode(output, datum)) return false;
+    comma = true;
+    if (!json_encode(output, data[i])) return false;
   };
   output << ']';
   return true;
-}
+};
+
+template <typename T, size_t N>
+bool json_encode(std::ostream& output, const std::array<T, N>& array) {
+  return json_encode(output, array.data(), array.size());
+};
+
+template <typename T>
+bool json_encode(std::ostream& output, const std::vector<T>& vector) {
+  return json_encode(output, vector.data(), vector.size());
+};
 
 template <typename T>
 bool json_encode(std::ostream& output, const std::map<std::string, T>& data) {

--- a/src/Store/Json.h
+++ b/src/Store/Json.h
@@ -29,7 +29,7 @@ bool json_encode(std::ostream& output, const std::vector<T>& data) {
       output << ',';
     else
       comma = true;
-    json_encode(output, datum);
+    if (!json_encode(output, datum)) return false;
   };
   output << ']';
   return true;
@@ -44,9 +44,9 @@ bool json_encode(std::ostream& output, const std::map<std::string, T>& data) {
       output << ',';
     else
       comma = true;
-    json_encode(output, datum.first);
+    if (!json_encode(output, datum.first)) return false;
     output << ':';
-    json_encode(output, datum.second);
+    if (!json_encode(output, datum.second)) return false;
   };
   output << '}';
   return true;

--- a/src/Store/Json.h
+++ b/src/Store/Json.h
@@ -78,6 +78,54 @@ bool json_encode(std::string& output, T data) {
   return true;
 }
 
+namespace json_internal {
+
+  inline bool json_encode_object_slots(std::ostream& output, bool& comma) {
+    return true;
+  };
+
+  template <typename Slot, typename... Rest>
+  bool json_encode_object_slots(
+      std::ostream& output,
+      bool& comma,
+      const char* name,
+      const Slot& slot,
+      Rest... rest
+  ) {
+    if (comma) output << ',';
+    comma = true;
+    output << '"' << name << '"' << ':';
+    if (!json_encode(output, slot)) return false;
+    return json_encode_object_slots(output, comma, rest...);
+  };
+
+  template <typename Slot, typename... Rest>
+  bool json_encode_object_slots(
+      std::ostream& output,
+      bool& comma,
+      const std::string& name,
+      const Slot& slot,
+      Rest... rest
+  ) {
+    return json_encode_object_slots(output, comma, name.c_str(), slot, rest...);
+  };
+
+}; // json_internal
+
+
+// A helper function to write fixed-size objects
+// Example: call `json_encode_object(output, "x", 42, "a", false)`
+// to produce `{"x":42,"a":false}`
+template <typename... Args>
+bool json_encode_object(std::ostream& output, Args... args) {
+  output << '{';
+  bool comma = false;
+  if (!json_internal::json_encode_object_slots(output, comma, args...))
+    return false;
+  output << '}';
+  return true;
 }
+
+}; // ToolFramework
 
 #endif

--- a/src/Store/Json.h
+++ b/src/Store/Json.h
@@ -17,6 +17,7 @@ json_encode(std::ostream& output, T datum) {
   return true;
 }
 
+bool json_encode(std::ostream& output, const char* datum);
 bool json_encode(std::ostream& output, const std::string& datum);
 
 template <typename T>


### PR DESCRIPTION
Provide `json_encode` for
* `char*`
* generic pointers (C arrays)
* `std::array`

Implement `json_encode_object` --- a helper function to construct JSON objects out of variables and literals.

There is a subtlety when it comes to extending `json_encode` for user-defined objects that I ran into while working on BUTTON high voltage control implementation, see 8361521. It needs further research. Please keep the commit message for the future.