### PR TITLE
Store: store structured data as JSON objects

### DIFF
--- a/UnitTests/StoreTest.cpp
+++ b/UnitTests/StoreTest.cpp
@@ -1,109 +1,525 @@
 #include <iostream>
+#include <functional>
+
+#include <string.h>
+
 #include <Store.h>
 
-using namespace ToolFramework;
+using ToolFramework::Store;
 
-int test_counter=0;
+class Tester {
+  public:
+    bool success = true;
 
-template <typename T> int Test(T &a, T &b, std::string message=""){
-test_counter++;
+    void operator()(bool result) {
+      success = success && result;
+    };
 
-if(a!=b){
-    std::cout<<"ERROR "<<test_counter<<" "<<message<<": "<<a<<"!="<<b<<std::endl;
-    return test_counter;
-}
-return 0;
+    operator bool() { return success; };
+};
 
-}
+template <>
+struct std::equal_to<Store> {
+  bool operator()(const Store& a, const Store& b) {
+    auto ia = a.begin();
+    auto ib = b.begin();
+    while (ia != a.end()) if (ib == b.end() || *ia++ != *ib++) return false;
+    return true;
+  };
+};
 
+// Compare two JSON strings neglecting whitespace
+// Skips whitespace and compares further characters. May produce false equals
+// when comparing strings within strings differing in whitespace, e.g.,
+// "{\"a\":\"q w\"}" "{\"a\":\"q  w\"}", but we don't expect those.
+static bool json_eq(const char* a, const char* b) {
+  while (*a && *b) {
+    if (*a != *b) {
+      while (isspace(*a)) ++a;
+      while (isspace(*b)) ++b;
+      if (*a != *b) return false;
+    };
+    ++a;
+    ++b;
+  };
+  while (isspace(*a)) ++a;
+  while (isspace(*b)) ++b;
+  return *a == *b;
+};
 
-int main(){
+template <typename T>
+std::ostream& operator<<(std::ostream&, const std::map<std::string, T>&);
 
-int ret=0;
-bool pass=true;
+template <typename T>
+std::ostream& operator<<(std::ostream& stream, const std::vector<T>& vector) {
+  stream << "[ ";
+  bool comma = false;
+  for (auto& x : vector) {
+    if (comma) stream << ", ";
+    comma = true;
+    stream << x;
+  };
+  return stream << " ]";
+};
 
-int a=1;
-short b=2;
-long c=3;
-float d=4.4;
-double e=5.5;
-bool f=true;
-char g='h';
-std::string h="hello world";
+template <typename T>
+std::ostream& operator<<(std::ostream& stream, const std::map<std::string, T>& map) {
+  stream << "{ ";
+  bool comma = false;
+  for (auto& kv : map) {
+    if (comma) stream << ", ";
+    comma = true;
+    stream << kv.first << " => " << kv.second;
+  };
+  return stream << " }";
+};
 
-unsigned int i=6;
-const int j=7;
+// Custom user class
+struct User {
+  std::string field;
 
+  User() {};
+  User(const char* f): field(f) {};
+  virtual ~User() {};
 
-Store store;
+  bool operator==(const User& u) const {
+    return field == u.field;
+  };
+};
 
-store.Set("a",a);
-store.Set("b",b);
-store.Set("c",c);
-store.Set("d",d);
-store.Set("e",e);
-store.Set("f",f);
-store.Set("g",g);
-store.Set("h",h);
-store.Set("i",i);
-store.Set("j",j);
-store.Set("k","hello world");
-store.Set("l",2);
-store.Set("m",4.4);
-store.Set("n",true);
+static void print(std::ostream& stream, const User& user) {
+  stream << "user " << user.field;
+};
 
-int a2=0;
-short b2=0;
-long c2=0;
-float d2=0;
-double e2=0;
-bool f2=false;
-char g2='0';
-std::string h2="";
-unsigned int i2=0;
-std::string k2="";
-short l2=0;
-float m2=0;
-bool n2=false;
+// Custom user class with implemented json encode/decode
+struct User1: public User {
+  User1() {};
+  User1(const char* f): User(f) {};
+};
 
+namespace ToolFramework {
+  static bool json_encode_r(std::ostream& stream, const User1& user, adl_tag tag) {
+    return json_encode_r(stream, user.field, tag);
+  };
 
- pass= pass && (store.Get("a",a2));
- pass= pass && (store.Get("b",b2));
- pass= pass && (store.Get("c",c2));
- pass= pass && (store.Get("d",d2));
- pass= pass && (store.Get("e",e2));
- pass= pass && (store.Get("f",f2));
- pass= pass && (store.Get("g",g2));
- pass= pass && (store.Get("h",h2));
- pass= pass && (store.Get("i",i2));
- const int j2=store.Get<int>("j");
- pass= pass && (store.Get("k",k2));
- pass= pass && (store.Get("l",l2));
- pass= pass && (store.Get("m",m2));
- pass= pass && (store.Get("n",n2));
+  static bool json_decode_r(const char*& input, User1& user, adl_tag tag) {
+    const char* i = input;
+    if (!json_decode_r(i, user.field, tag)) return false;
+    input = i;
+    return true;
+  };
+};
 
+// Custom user class with implemented input/output operators
+struct User2: public User {
+  User2() {};
+  User2(const char* f): User(f) {};
+};
 
-bool tmp=true;
-ret+=Test(pass,tmp, "Get Fail");
+static std::ostream& operator<<(std::ostream& output, const User2& user) {
+  return output << user.field;
+};
 
-ret+=Test(a,a2);
-ret+=Test(b,b2);
-ret+=Test(c,c2);
-ret+=Test(d,d2);
-ret+=Test(e,e2);
-ret+=Test(f,f2);
-ret+=Test(g,g2);
-ret+=Test(h,h2);
-ret+=Test(i,i2);
-ret+=Test(j,j2);
-ret+=Test(h,k2);
-ret+=Test(b,l2);
-ret+=Test(d,m2);
-ret+=Test(f,n2);
+static std::istream& operator>>(std::istream& input, User2& user) {
+  return input >> user.field;
+};
 
-store.Print();
+// Custom user class with implemented both json encode/decode and input/output
+// operators
+struct User3: public User {
+  User3() {};
+  User3(const char* f): User(f) {};
+};
 
+namespace ToolFramework {
+  static bool json_encode_r(
+      std::ostream& stream, const User3& user, adl_tag tag
+  ) {
+    return json_encode_r(stream, user.field, tag);
+  };
 
-return ret;
+  static bool json_decode_r(
+      const char*& input, User3& user, adl_tag tag
+  ) {
+    const char* i = input;
+    if (!json_decode_r(i, user.field, tag)) return false;
+    input = i;
+    return true;
+  };
+};
 
-}
+static std::ostream& operator<<(std::ostream& output, const User3& user) {
+  return output << user.field;
+};
+
+static std::istream& operator>>(std::istream& input, User3& user) {
+  return input >> user.field;
+};
+
+// Custom user class with json encode/decode implemented through inheritance
+struct User4: public User1 {
+  User4() {};
+  User4(const char* f): User1(f) {};
+};
+
+// Custom user class with both json encode/decode and input/output operators
+// implemented through inheritance
+struct User5: public User3 {
+  User5() {};
+  User5(const char* f): User3(f) {};
+};
+
+// Custom user class with json encode/decode implemented through inheritance
+// and custom input/output operators
+struct User6: public User1 {
+  User6() {};
+  User6(const char* f): User1(f) {};
+};
+
+static std::ostream& operator<<(std::ostream& output, const User6& user) {
+  return output << user.field;
+};
+
+static std::istream& operator>>(std::istream& input, User6& user) {
+  return input >> user.field;
+};
+
+template <typename T, typename Eq = std::equal_to<T>>
+static bool test_var(
+    const char* key,
+    const T& value,
+    const char* json = nullptr,
+    Eq eq = std::equal_to<T>(),
+    const std::function<void (std::ostream&, const T&)>& printer
+      = [](std::ostream& stream, const T& value) { stream << value; }
+) {
+  auto log = [&]() -> std::ostream& {
+    std::cout
+      << "test_var<"
+      << typeid(T).name()
+      << "> `"
+      << key
+      << '\'';
+    if (printer) {
+      std::cout << " `";
+      printer(std::cout, value);
+      std::cout << '\'';
+    };
+    return std::cout << ": ";
+  };
+
+  Store store;
+  store.Set(key, value);
+
+  T value2;
+  store.Get(key, value2);
+  if (!eq(value, value2)) {
+    log() << "Get returned `";
+    printer(std::cout, value2);
+    std::cout << "'. Store contents:\n";
+    store.Print();
+    return false;
+  };
+
+  std::string json2;
+  store >> json2;
+  if (json && !json_eq(json, json2.c_str())) {
+    log()
+      << "JSON mismatch: expected `"
+      << json
+      << "', got `"
+      << json2
+      << "'. Store contents:\n";
+    store.Print();
+    return false;
+  };
+
+  Store store2;
+  if (!store2.JsonParser(json2)) {
+    log() << "JsonParser failed on `" << json2 << "'\n";
+    return false;
+  };
+
+  store2.Get(key, value2);
+  if (!eq(value, value2)) {
+    log() << "Get after deserialization returned `";
+    printer(std::cout, value2);
+    std::cout << "'\n";
+    return false;
+  };
+
+  return true;
+};
+
+static bool test_json(
+    const char* json,
+    bool valid = true,
+    const char* expected = nullptr
+) {
+  if (!expected) expected = json;
+
+  auto log = [&]() -> std::ostream& {
+    return std::cout << "test_json `" << json << "': ";
+  };
+
+  Store store;
+  if (store.JsonParser(json) != valid) {
+    log()
+      << "JsonParser "
+      << (valid ? "failed" : "unexpectedly succeeded")
+      << '\n';
+    return false;
+  };
+
+  std::string json2;
+  store >> json2;
+
+  if (!json_eq(expected, json2.c_str())) {
+    log() << "JSON mismatch: got `" << json2 << "'\n";
+    return false;
+  };
+
+  return true;
+};
+
+int main(int argc, char** argv) {
+  Tester t;
+
+  t(test_var("a", 1, "{\"a\":1}"));
+  t(test_var("b", static_cast<short>(2), "{\"b\":2}"));
+  t(test_var("c", 3L, "{\"c\":3}"));
+  t(test_var("d", 4.4f, "{\"d\":4.4}"));
+  t(test_var("e", 5.5, "{\"e\":5.5}"));
+  t(test_var("f", true, "{\"f\":1}"));
+  t(test_var("g", 'h', "{\"g\":\"h\"}"));
+  t(test_var<std::string>("h", "hello world", "{\"h\":\"hello world\"}"));
+
+  // TODO: make it work with const char*
+  t(test_var<std::string>("i", "q \" w", "{\"i\":\"q \\\" w\"}"));
+
+  {
+    Store s;
+    s.Set("a", "q } w");
+    t(test_var("j", s, "{\"j\":{\"a\":\"q } w\"}}"));
+  };
+
+  t(test_var<std::string>("k", "{\"a\":{\"q } w\"}}", "{\"k\":\"{\\\"a\\\":{\\\"q } w\\\"}}\"}"));
+  t(test_var("l", std::vector<int> { 42, 11 }, "{\"l\":[42,11]}"));
+
+  t(
+      test_var(
+        "m",
+        std::vector<float> { -2.5e-10, -0.1, 0.1, 2.5e10 },
+        "{\"m\":[-2.5e-10,-0.1,0.1,2.5e+10]}"
+      )
+  );
+
+  {
+    Store s;
+    s.Set("x", std::vector<int> { -5, 5 });
+    s.Set("y", std::vector<float> { 0, 1.333 });
+    t(test_var("n", s, "{\"n\":{\"x\":[-5,5],\"y\":[0,1.333]}}"));
+  };
+
+  t(
+      test_var(
+        "o",
+        std::vector<std::string> { "qwe , asd", "q \"}] w" },
+        "{\"o\":[\"qwe , asd\",\"q \\\"}] w\"]}"
+      )
+  );
+
+  t(
+      test_var(
+        "p",
+        std::vector<std::vector<int>> { { 1, 2 }, { -1, -2 } },
+        "{\"p\":[[1,2],[-1,-2]]}"
+      )
+  );
+
+  t(
+      test_var(
+        "q",
+        std::map<std::string, std::string> {
+          { "a", "qwe" },
+          { "q \" w", "x } z" }
+        },
+        "{\"q\":{\"a\":\"qwe\",\"q \\\" w\":\"x } z\"}}"
+      )
+  );
+
+  t(
+      test_var(
+        "r",
+        std::vector<std::map<std::string, std::vector<int>>> {
+          {
+            { "a", { 1, 2 } },
+            { "b", { -1, -2 } }
+          },
+          {
+            { "q \" w", { 0, 42 } },
+            { "x ] z", { 15, 11 } }
+          }
+        },
+        "{\"r\":[{\"a\":[1,2],\"b\":[-1,-2]},{\"q \\\" w\":[0,42],\"x ] z\":[15,11]}]}"
+      )
+  );
+
+  t(
+      test_var(
+        "user1",
+        User1("user1"),
+        "{\"user1\":\"user1\"}",
+        std::equal_to<User1>(),
+        std::function<void (std::ostream&, const User1&)>(print)
+      )
+  );
+
+  t(
+      test_var(
+        "user2",
+        User2("user2"),
+        "{\"user2\":\"user2\"}",
+        std::equal_to<User2>(),
+        std::function<void (std::ostream&, const User2&)>(print)
+      )
+  );
+
+  t(
+      test_var(
+        "user3",
+        User3("user3"),
+        "{\"user3\":\"user3\"}",
+        std::equal_to<User3>(),
+        std::function<void (std::ostream&, const User3&)>(print)
+      )
+  );
+
+  t(
+      test_var(
+        "user4",
+        User4("user4"),
+        "{\"user4\":\"user4\"}",
+        std::equal_to<User4>(),
+        std::function<void (std::ostream&, const User4&)>(print)
+      )
+  );
+
+  t(
+      test_var(
+        "user5",
+        User5("user5"),
+        "{\"user5\":\"user5\"}",
+        std::equal_to<User5>(),
+        std::function<void (std::ostream&, const User5&)>(print)
+      )
+  );
+
+  t(
+      test_var(
+        "user6",
+        User6("user6"),
+        "{\"user6\":\"user6\"}",
+        std::equal_to<User6>(),
+        std::function<void (std::ostream&, const User6&)>(print)
+      )
+  );
+
+  t(
+      test_json(
+        "{\"key\":[{\"a\":{\"b\":[1,false]}},{\"a\":{\"b\":[null,-2.5e-2]}}]}"
+      )
+  );
+
+  // adapted from https://github.com/briandfoy/json-acceptance-tests, pass1
+  {
+    const char* json =
+      "{\n"
+"        \"integer\": 1234567890,\n"
+"        \"real\": -9876.543210,\n"
+"        \"e\": 0.123456789e-12,\n"
+"        \"E\": 1.234567890E+34,\n"
+"        \"\":  23456789012E66,\n"
+"        \"zero\": 0,\n"
+"        \"one\": 1,\n"
+"        \"space\": \" \",\n"
+"        \"quote\": \"\\\"\",\n"
+"        \"backslash\": \"\\\\\",\n"
+"        \"controls\": \"\\b\\f\\n\\r\\t\",\n"
+"        \"slash\": \"/ & \\/\",\n"
+"        \"alpha\": \"abcdefghijklmnopqrstuvwyz\",\n"
+"        \"ALPHA\": \"ABCDEFGHIJKLMNOPQRSTUVWYZ\",\n"
+"        \"digit\": \"0123456789\",\n"
+"        \"0123456789\": \"digit\",\n"
+"        \"special\": \"`1~!@#$%^&*()_+-={':[,]}|;.</>?\",\n"
+"        \"hex\": \"\\u0123\\u4567\\u89AB\\uCDEF\\uabcd\\uef4A\",\n"
+"        \"true\": true,\n"
+"        \"false\": false,\n"
+"        \"null\": null,\n"
+"        \"array\":[  ],\n"
+"        \"object\":{  },\n"
+"        \"address\": \"50 St. James Street\",\n"
+"        \"url\": \"http://www.JSON.org/\",\n"
+"        \"comment\": \"// /* <!-- --\",\n"
+"        \"# -- --> */\": \" \",\n"
+"        \" s p a c e d \" :[1,2 , 3\n"
+"\n"
+",\n"
+"\n"
+"4 , 5        ,          6           ,7        ],\"compact\":[1,2,3,4,5,6,7],\n"
+"        \"jsontext\": \"{\\\"object with 1 member\\\":[\\\"array with 1 element\\\"]}\",\n"
+"        \"quotes\": \"&#34; \\u0022 %22 0x22 034 &#x22;\",\n"
+"        \"\\/\\\\\\\"\\uCAFE\\uBABE\\uAB98\\uFCDE\\ubcda\\uef4A\\b\\f\\n\\r\\t`1~!@#$%^&*()_+-=[]{}|;:',./<>?\"\n"
+": \"A key can be any string\"\n"
+"    }"
+    ;
+
+    const char* expected =
+"      {\n"
+"              \"\":  23456789012E66,\n"
+"              \" s p a c e d \" :[1,2 , 3\n"
+"\n"
+"      ,\n"
+"\n"
+"      4 , 5        ,          6           ,7        ],\n"
+"              \"# -- --> */\": \" \",\n"
+"              \"/\\\\\\\"\\ucafe\\ubabe\\uab98\\ufcde\\ubcda\\uef4a\\b\\f\\n\\r\\t`1~!@#$%^&*()_+-=[]{}|;:',./<>?\"\n"
+"      : \"A key can be any string\",\n"
+"              \"0123456789\": \"digit\",\n"
+"              \"ALPHA\": \"ABCDEFGHIJKLMNOPQRSTUVWYZ\",\n"
+"              \"E\": 1.234567890E+34,\n"
+"              \"address\": \"50 St. James Street\",\n"
+"              \"alpha\": \"abcdefghijklmnopqrstuvwyz\",\n"
+"              \"array\":[  ],\n"
+"              \"backslash\": \"\\\\\",\n"
+"              \"comment\": \"// /* <!-- --\","
+"\"compact\":[1,2,3,4,5,6,7],\n"
+"              \"controls\": \"\\b\\f\\n\\r\\t\",\n"
+"              \"digit\": \"0123456789\",\n"
+"              \"e\": 0.123456789e-12,\n"
+"              \"false\": 0,\n"
+"              \"hex\": \"\\u0123Eg\\u89ab\\ucdef\\uabcd\\uef4a\",\n"
+"              \"integer\": 1234567890,\n"
+"              \"jsontext\": \"{\\\"object with 1 member\\\":[\\\"array with 1 element\\\"]}\",\n"
+"              \"null\": 0,\n"
+"              \"object\":{  },\n"
+"              \"one\": 1,\n"
+"              \"quote\": \"\\\"\",\n"
+"              \"quotes\": \"&#34; \\\" %22 0x22 034 &#x22;\",\n"
+"              \"real\": -9876.543210,\n"
+"              \"slash\": \"/ & /\",\n"
+"              \"space\": \" \",\n"
+"              \"special\": \"`1~!@#$%^&*()_+-={':[,]}|;.</>?\",\n"
+"              \"true\": 1,\n"
+"              \"url\": \"http://www.JSON.org/\",\n"
+"              \"zero\": 0\n"
+"      }\n"
+    ;
+
+    t(test_json(json, true, expected));
+  };
+
+  if (t) std::cout << "ok\n";
+
+  return 0;
+};

--- a/src/Store/BStore.cpp
+++ b/src/Store/BStore.cpp
@@ -957,7 +957,7 @@ BStore::~BStore(){
 }
 
 namespace ToolFramework {
-  bool json_encode(std::ostream& output, const BStore& store) {
+  bool json_encode_r(std::ostream& output, const BStore& store, adl_tag) {
     return store.JsonEncode(output);
   }
 }

--- a/src/Store/BStore.h
+++ b/src/Store/BStore.h
@@ -258,7 +258,7 @@ namespace ToolFramework{
     
   };
 
-  bool json_encode(std::ostream&, const BStore&);
+  bool json_encode_r(std::ostream&, const BStore&, adl_tag);
 }
 
 #endif

--- a/src/Store/Json.cpp
+++ b/src/Store/Json.cpp
@@ -1,19 +1,381 @@
+#include <iomanip>
+
+#include <cstdint>
+#include <cstring>
+
 #include <Json.h>
 
 namespace ToolFramework {
 
-bool json_encode(std::ostream& output, const char* datum) {
+static bool json_encode(
+    std::ostream& output,
+    const char* begin,
+    const char* end
+) {
   output << '"';
-  while (*datum) {
-    if (*datum == '"' || *datum == '\\') output << '\\';
-    output << *datum;
-  };
+  for (auto c = begin; c < end; ++c)
+    switch (*c) {
+      case '\a':
+        output << "\\a";
+        break;
+      case '\b':
+        output << "\\b";
+        break;
+      case '\f':
+        output << "\\f";
+        break;
+      case '\n':
+        output << "\\n";
+        break;
+      case '\r':
+        output << "\\r";
+        break;
+      case '\t':
+        output << "\\t";
+        break;
+      case '\\':
+      case '"':
+        output << '\\' << *c;
+        break;
+      default:
+        {
+          uint8_t byte = static_cast<uint8_t>(*c);
+          if (byte < 0x20 || byte > 0x7F) {
+            uint16_t codepoint = byte;
+            if (++c != end)
+              codepoint = codepoint << 8 | static_cast<uint8_t>(*c);
+            output
+              << "\\u"
+              << std::setw(4)
+              << std::setfill('0')
+              << std::hex
+              << codepoint
+              << std::dec;
+          } else
+            output << byte;
+        };
+    };
   output << '"';
   return true;
 }
 
-bool json_encode(std::ostream& output, const std::string& datum) {
-  return json_encode(output, datum.c_str());
+bool json_encode(
+    std::ostream& output,
+    std::string::const_iterator begin,
+    std::string::const_iterator end
+) {
+  return json_encode(output, &*begin, &*end);
+}
+
+bool json_encode_r(std::ostream& output, const std::string& datum, adl_tag) {
+  return json_encode(output, datum.begin(), datum.end());
+}
+
+bool json_encode_r(std::ostream& output, const char* datum, adl_tag) {
+  return json_encode(output, datum, datum + strlen(datum));
+}
+
+const char* json_scan_whitespace(const char* input) {
+  if (!input) return nullptr;
+  while (isspace(*input)) ++input;
+  return input;
+}
+
+const char* json_scan_token(const char* input, char token) {
+  input = json_scan_whitespace(input);
+  return input && *input == token ? input + 1 : nullptr;
+}
+
+const char* json_scan_token(const char* input, const char* token) {
+  input = json_scan_whitespace(input);
+  if (!input) return nullptr;
+  while (*token) if (*input++ != *token++) return nullptr;
+  return isalnum(*input) ? nullptr : input;
+}
+
+const char* json_scan_number(const char* input) {
+  input = json_scan_whitespace(input);
+  if (!input) return nullptr;
+
+  if (*input == '-' || *input == '+') ++input;
+  while (isdigit(*input)) ++input;
+  if (*input == '.') {
+    ++input;
+    while (isdigit(*input)) ++input;
+  };
+  if (tolower(*input) == 'e') {
+    ++input;
+    if (*input == '-' || *input == '+') ++input;
+    while (isdigit(*input)) ++input;
+  };
+
+  return isalnum(*input) ? nullptr : input;
+}
+
+const char* json_scan_string(const char* input) {
+  input = json_scan_token(input, '"');
+  if (!input) return nullptr;
+
+  bool escaped = false;
+  for (; *input; ++input)
+    if (escaped)
+      escaped = false;
+    else
+      switch (*input) {
+        case '\\':
+          escaped = true;
+          break;
+        case '"':
+          return input + 1;
+          break;
+        default:
+          break;
+      };
+
+  return nullptr;
+}
+
+static const char* json_scan_list(
+    const char* input,
+    char start,
+    char end,
+    const char* (*scan_item)(const char*)
+) {
+  bool comma = false;
+  input = json_scan_token(input, start);
+  while (input) {
+    input = json_scan_whitespace(input);
+    if (*input == end) return input + 1;
+
+    if (comma) {
+      if (*input++ != ',') return nullptr;
+    } else
+      comma = true;
+
+    input = scan_item(input);
+  };
+  return nullptr;
+}
+
+const char* json_scan_object(const char* input) {
+  return json_scan_list(
+      input, '{', '}',
+      [](const char* i) -> const char* {
+        i = json_scan_string(i);
+        i = json_scan_token(i, ':');
+        return json_scan(i);
+    }
+  );
+}
+
+const char* json_scan_array(const char* input) {
+  return json_scan_list(input, '[', ']', json_scan);
+}
+
+const char* json_scan(const char* input) {
+  input = json_scan_whitespace(input);
+  if (!input) return nullptr;
+  switch (*input) {
+    case 'f':
+      return json_scan_token(input, "false");
+    case 't':
+      return json_scan_token(input, "true");
+    case 'n':
+      return json_scan_token(input, "null");
+    case '-':
+    case '+':
+    case '0':
+    case '1':
+    case '2':
+    case '3':
+    case '4':
+    case '5':
+    case '6':
+    case '7':
+    case '8':
+    case '9':
+      return json_scan_number(input);
+    case '"':
+      return json_scan_string(input);
+    case '{':
+      return json_scan_object(input);
+    case '[':
+      return json_scan_array(input);
+    default:
+      return nullptr;
+  };
+}
+
+bool json_decode_r(const char*& input, bool& value, adl_tag) {
+  const char* i = json_scan_whitespace(input);
+  if (!i) return false;
+
+  switch (*i) {
+    case 'f':
+      i = json_scan_token(i, "false");
+      if (!i) return false;
+      value = false;
+      break;
+    case 't':
+      i = json_scan_token(i, "true");
+      if (!i) return false;
+      value = true;
+      break;
+    case '0':
+      if (isalnum(*++i)) return false;
+      value = false;
+      break;
+    case '1':
+      if (isalnum(*++i)) return false;
+      value = true;
+      break;
+    default:
+      return false;
+  };
+
+  input = i;
+  return true;
+}
+
+namespace json_internal {
+
+bool json_decode_string(
+    const char*& input,
+    std::string& value,
+    bool keep_quotes
+) {
+  const char* i = json_scan_token(input, '"');
+  if (!i) return false;
+
+  std::stringstream ss;
+  if (keep_quotes) ss << '"';
+
+  bool escaped = false;
+  for (; *i; ++i) {
+    if (escaped) {
+      escaped = false;
+      switch (*i) {
+        case '\\':
+          ss << '\\';
+          break;
+        case 'a':
+          ss << '\a';
+          break;
+        case 'b':
+          ss << '\b';
+          break;
+        case 'f':
+          ss << '\f';
+          break;
+        case 'n':
+          ss << '\n';
+          break;
+        case 'r':
+          ss << '\r';
+          break;
+        case 't':
+          ss << '\t';
+          break;
+        case 'u':
+          {
+            uint16_t codepoint = 0;
+            for (int b = 0; b < 2; ++b) {
+              for (int d = 0; d < 2; ++d) {
+                char digit = *++i;
+                if (digit >= '0' && digit <= '9')
+                  digit -= '0';
+                else if (digit >= 'a' && digit <= 'f')
+                  digit = digit - 'a' + 10;
+                else if (digit >= 'A' && digit <= 'F')
+                  digit = digit - 'A' + 10;
+                else
+                  return false; // TODO: invalid string
+                codepoint = codepoint << 4 | digit;
+              };
+            };
+            if (codepoint > 0xFF) ss << static_cast<char>(codepoint >> 8);
+            ss << static_cast<char>(codepoint & 0xFF);
+          };
+          break;
+        default:
+          // TODO: invalid escape sequence. Store anyway?
+          ss << *i;
+      };
+    } else {
+      switch (*i) {
+        case '\\':
+          escaped = true;
+          continue;
+        case '"':
+          if (keep_quotes) ss << '"';
+          input = ++i;
+          value = ss.str();
+          return true;
+        default:
+          ss << *i;
+      };
+    };
+  };
+
+  return false;
+}
+
+}
+
+bool json_decode_r(const char*& input, std::string& value, adl_tag) {
+  return json_internal::json_decode_string(input, value, false);
+}
+
+static bool json_decode_list(
+    const char*& input,
+    char start,
+    char end,
+    const std::function<bool (const char*&)> decode_item
+) {
+  const char* i = json_scan_token(input, start);
+  if (!i) return false;
+
+  bool comma = false;
+  while (true) {
+    i = json_scan_whitespace(i);
+    if (*i == end) break;
+
+    if (comma) {
+      if (*i++ != ',') return false;
+    } else
+      comma = true;
+
+    if (!decode_item(i)) return false;
+  };
+
+  input = i + 1;
+  return true;
+}
+
+bool json_decode_array(
+    const char*& input,
+    const std::function<bool (const char*&)>& decode_item
+) {
+  return json_decode_list(input, '[', ']', decode_item);
+}
+
+bool json_decode_object(
+    const char*& input,
+    const std::function<bool (const char*&, std::string)>& decode_value
+) {
+  return json_decode_list(
+      input, '{', '}',
+      [&](const char*& input_) -> bool {
+        const char* i = input_;
+        std::string key;
+        if (!json_decode_r(i, key, adl_tag {})) return false;
+        i = json_scan_token(i, ':');
+        if (!i) return false;
+        if (!decode_value(i, std::move(key))) return false;
+        input_ = i;
+        return true;
+      }
+  );
 }
 
 }

--- a/src/Store/Json.cpp
+++ b/src/Store/Json.cpp
@@ -206,6 +206,12 @@ const char* json_scan(const char* input) {
   };
 }
 
+bool json_valid(const char* input) {
+  input = json_scan(input);
+  input = json_scan_whitespace(input);
+  return input && !*input;
+};
+
 bool json_decode_r(const char*& input, bool& value, adl_tag) {
   const char* i = json_scan_whitespace(input);
   if (!i) return false;

--- a/src/Store/Json.h
+++ b/src/Store/Json.h
@@ -100,6 +100,8 @@ const char* json_scan_object(const char* input);
 const char* json_scan_array(const char* input);
 const char* json_scan(const char* input); // generic
 
+bool json_valid(const char* input);
+
 
 // json_encode_r implements encoding of specific objects. Add overloads to this
 // function to support custom classes.

--- a/src/Store/Json.h
+++ b/src/Store/Json.h
@@ -1,82 +1,173 @@
 #ifndef TOOLFRAMEWORK_JSON_H
 #define TOOLFRAMEWORK_JSON_H
 
+#include <functional>
 #include <map>
 #include <ostream>
 #include <sstream>
 #include <string>
 #include <type_traits>
+#include <unordered_map>
 #include <vector>
+
+
+/**
+   This file provides functions working with JSON.
+
+   Three families of functions are provided: json_encode for JSON
+   serialization, json_scan for JSON validation, and json_decode for JSON
+   parsing.
+*/
 
 namespace ToolFramework {
 
-template <typename T, size_t N>
-bool json_encode(std::ostream&, const std::array<T, N>&);
+/**
+   JSON serialization functions
 
-template <typename T>
-bool json_encode(std::ostream&, const std::vector<T>&);
+   json_encode comes in two flavours: json_encode(std::ostream&, const T&)
+   serializes a value into a stream, json_encode(std::string&, const T&)
+   serializes a value into a string. The latter calls the former, and the
+   former calls json_encode_r to encode specific objects. Provide overloads of
+   json_encode_r function or template to extend for custom classes.
 
-template <typename T>
-bool json_encode(std::ostream&, const std::map<std::string, T>&);
+   json_encode returns false if encoding has failed; for the function working
+   with a stream it can only happen in user extensions, functions in this file
+   always return true. json_encode(std::string&, const T&) checks the stream
+   flags.
+*/
+
+template <typename T> bool json_encode(std::ostream& output, const T& datum);
+template <typename T> bool json_encode(std::string& output, const T& datum);
+
+// Encode a part of a string as a string
+bool json_encode(
+    std::ostream& output,
+    std::string::const_iterator begin,
+    std::string::const_iterator end
+);
+
+// A helper function to write fixed-size objects
+// Example: call `json_encode_object(output, "x", 42, "a", false)`
+// to produce `{"x":42,"a":false}`
+template <typename... Fields>
+bool json_encode_object(std::ostream& output, Fields... fields);
+
+/*
+   JSON decoder function
+   Use this if you know the structure of JSON data in advance
+
+   Returns false if the JSON string is invalid.
+   If the object was decoded successfully, input is set one character past it,
+   otherwise it is left unchanged.
+*/
+template <typename T> bool json_decode(const char*& input, T& value);
+
+// Expects an array in input, calls decode_item(item) on each array item
+bool json_decode_array(
+    const char*& input,
+    const std::function<bool (const char*& /* input */)>& decode_item
+);
+
+// Expects an object in input, calls decode_value(key, value) on each key-value pair
+bool json_decode_object(
+    const char*& input,
+    const std::function<bool (const char*& /* input */, std::string /* key */)>&
+      decode_value
+);
+
+// A class to trigger argument-dependent lookup (ADL) in json_encode_r and
+// json_decode_r functions. It is required for the compiler to find overloads
+// declared after this file. See
+// https://akrzemi1.wordpress.com/2016/01/16/a-customizable-framework/
+// for caveats.
+struct adl_tag {};
+
+
+/**
+   JSON scanner functions
+
+   Scanner functions find the end of an object without further interpretation.
+
+   Each function returns nullptr if the JSON string is invalid.
+   It is okay to pass nullptr as input.
+*/
+const char* json_scan_whitespace(const char* input);
+const char* json_scan_token(const char* input, char token);
+const char* json_scan_token(const char* input, const char* token);
+const char* json_scan_number(const char* input);
+const char* json_scan_string(const char* input);
+const char* json_scan_object(const char* input);
+const char* json_scan_array(const char* input);
+const char* json_scan(const char* input); // generic
+
+
+// json_encode_r implements encoding of specific objects. Add overloads to this
+// function to support custom classes.
 
 template <typename T>
 typename std::enable_if<std::is_arithmetic<T>::value, bool>::type
-json_encode(std::ostream& output, T datum) {
-  output << datum;
-  return true;
-}
+json_encode_r(std::ostream& output, T datum, adl_tag);
 
-bool json_encode(std::ostream& output, const char* datum);
-bool json_encode(std::ostream& output, const std::string& datum);
+bool json_encode_r(std::ostream& output, const std::string& datum, adl_tag);
+
+bool json_encode_r(std::ostream& output, const char* datum, adl_tag);
 
 template <typename T>
-bool json_encode(std::ostream& output, const T* data, size_t size) {
-  output << '[';
-  bool comma = false;
-  for (size_t i = 0; i < size; ++i) {
-    if (comma)
-      output << ',';
-    comma = true;
-    if (!json_encode(output, data[i])) return false;
-  };
-  output << ']';
-  return true;
-}
+bool json_encode_r(std::ostream& output, const T* data, size_t size, adl_tag);
 
 template <typename T, size_t N>
-bool json_encode(std::ostream& output, const std::array<T, N>& array) {
-  return json_encode(output, array.data(), array.size());
-}
+bool json_encode_r(std::ostream&, const std::array<T, N>&, adl_tag);
 
 template <typename T>
-bool json_encode(std::ostream& output, const std::vector<T>& vector) {
-  return json_encode(output, vector.data(), vector.size());
-}
+bool json_encode_r(std::ostream&, const std::vector<T>&, adl_tag);
 
 template <typename T>
-bool json_encode(std::ostream& output, const std::map<std::string, T>& data) {
-  output << '{';
-  bool comma = false;
-  for (auto& datum : data) {
-    if (comma)
-      output << ',';
-    else
-      comma = true;
-    if (!json_encode(output, datum.first)) return false;
-    output << ':';
-    if (!json_encode(output, datum.second)) return false;
-  };
-  output << '}';
-  return true;
-}
+bool json_encode_r(std::ostream&, const std::map<std::string, T>&, adl_tag);
+
+// json_decode_r implements decoding of specific objects. Add overloads to this
+// function to support custom classes.
+
+bool json_decode_r(const char*& input, bool& value, adl_tag);
 
 template <typename T>
-bool json_encode(std::string& output, T data) {
-  std::stringstream ss;
-  if (!json_encode(ss, data)) return false;
-  output = ss.str();
-  return true;
-}
+typename std::enable_if<
+  std::is_integral<T>::value && std::is_signed<T>::value,
+  bool
+>::type
+json_decode_r(const char*& input, T& value, adl_tag);
+
+template <typename T>
+typename std::enable_if<
+  std::is_integral<T>::value && !std::is_signed<T>::value,
+  bool
+>::type
+json_decode_r(const char*& input, T& value);
+
+template <typename T>
+typename std::enable_if<std::is_floating_point<T>::value, bool>::type
+json_decode_r(const char*& input, T& value, adl_tag);
+
+bool json_decode_r(const char*& input, std::string& value, adl_tag);
+
+template <typename T>
+bool json_decode_r(const char*& input, std::vector<T>& value, adl_tag);
+
+template <typename T>
+bool json_decode_r(
+    const char*& input,
+    std::map<std::string, T>& value,
+    adl_tag
+);
+
+template <typename T>
+bool json_decode_r(
+    const char*& input,
+    std::unordered_map<std::string, T>& value,
+    adl_tag
+);
+
+
+// Implementation
 
 namespace json_internal {
 
@@ -95,7 +186,7 @@ namespace json_internal {
     if (comma) output << ',';
     comma = true;
     output << '"' << name << '"' << ':';
-    if (!json_encode(output, slot)) return false;
+    if (!json_encode_r(output, slot, adl_tag {})) return false;
     return json_encode_object_slots(output, comma, rest...);
   }
 
@@ -110,12 +201,27 @@ namespace json_internal {
     return json_encode_object_slots(output, comma, name.c_str(), slot, rest...);
   }
 
+  bool json_decode_string(
+      const char*& input,
+      std::string& value,
+      bool keep_quotes
+  );
+
 } // json_internal
 
+template <typename T>
+bool json_encode(std::ostream& output, const T& datum) {
+  return json_encode_r(output, datum, adl_tag {});
+}
 
-// A helper function to write fixed-size objects
-// Example: call `json_encode_object(output, "x", 42, "a", false)`
-// to produce `{"x":42,"a":false}`
+template <typename T>
+bool json_encode(std::string& output, const T& datum) {
+  std::stringstream ss;
+  if (!json_encode(ss, datum) || !ss) return false;
+  output = ss.str();
+  return true;
+}
+
 template <typename... Args>
 bool json_encode_object(std::ostream& output, Args... args) {
   output << '{';
@@ -124,6 +230,171 @@ bool json_encode_object(std::ostream& output, Args... args) {
     return false;
   output << '}';
   return true;
+}
+
+template <typename T>
+bool json_decode(const char*& input, T& value) {
+  return json_decode_r(input, value, adl_tag {});
+}
+
+template <typename T>
+typename std::enable_if<std::is_arithmetic<T>::value, bool>::type
+json_encode_r(std::ostream& output, T datum, adl_tag) {
+  output << datum;
+  return true;
+}
+
+template <typename T>
+bool json_encode_r(std::ostream& output, const T* data, size_t size, adl_tag tag) {
+  output << '[';
+  bool comma = false;
+  for (size_t i = 0; i < size; ++i) {
+    if (comma)
+      output << ',';
+    comma = true;
+    if (!json_encode_r(output, data[i], tag)) return false;
+  };
+  output << ']';
+  return true;
+}
+
+template <typename T, size_t N>
+bool json_encode_r(
+    std::ostream& output,
+    const std::array<T, N>& array,
+    adl_tag tag
+) {
+  return json_encode_r(output, array.data(), array.size(), tag);
+}
+
+template <typename T>
+bool json_encode_r(
+    std::ostream& output,
+    const std::vector<T>& vector,
+    adl_tag tag
+) {
+  return json_encode_r(output, vector.data(), vector.size(), tag);
+}
+
+template <typename Map, typename T>
+bool json_encode_r_map(std::ostream& output, const Map& data, adl_tag tag) {
+  output << '{';
+  bool comma = false;
+  for (auto& datum : data) {
+    if (comma)
+      output << ',';
+    else
+      comma = true;
+    if (!json_encode_r(output, datum.first, tag)) return false;
+    output << ':';
+    if (!json_encode_r(output, datum.second, tag)) return false;
+  };
+  output << '}';
+  return true;
+}
+
+template <typename T>
+bool json_encode_r(
+    std::ostream& output,
+    const std::map<std::string, T>& data,
+    adl_tag tag
+) {
+  return json_encode_r_map<std::map<std::string, T>, T>(output, data, tag);
+}
+
+template <typename T>
+bool json_encode_r(
+    std::ostream& output,
+    const std::unordered_map<std::string, T>& data,
+    adl_tag tag
+) {
+  return json_encode_r_map<std::unordered_map<std::string, T>, T>(
+      output, data, tag
+  );
+}
+
+template <typename T>
+typename std::enable_if<
+  std::is_integral<T>::value && std::is_signed<T>::value,
+  bool
+>::type
+json_decode_r(const char*& input, T& value, adl_tag) {
+  char* i;
+  value = strtol(input, &i, 10);
+  if (isalnum(*i)) return false;
+  input = i;
+  return true;
+}
+
+template <typename T>
+typename std::enable_if<
+  std::is_integral<T>::value && !std::is_signed<T>::value,
+  bool
+>::type
+json_decode_r(const char*& input, T& value, adl_tag) {
+  char* i;
+  value = strtoul(input, &i, 10);
+  if (isalnum(*i)) return false;
+  input = i;
+  return true;
+}
+
+template <typename T>
+typename std::enable_if<std::is_floating_point<T>::value, bool>::type
+json_decode_r(const char*& input, T& value, adl_tag) {
+  char* i;
+  value = strtod(input, &i);
+  if (isalnum(*i)) return false;
+  input = i;
+  return true;
+}
+
+template <typename T>
+bool json_decode_r(const char*& input, std::vector<T>& value, adl_tag tag) {
+  value.clear();
+  return json_decode_array(
+      input,
+      [&](const char*& i) -> bool {
+        T item;
+        if (!json_decode_r(i, item, tag)) return false;
+        value.push_back(std::move(item));
+        return true;
+      }
+  );
+}
+
+template <typename Map, typename T>
+bool json_decode_r_map(const char*& input, Map& value, adl_tag tag) {
+  value.clear();
+  return json_decode_object(
+      input,
+      [&](const char*& i, std::string key) -> bool {
+        T item;
+        if (!json_decode_r(i, item, tag)) return false;
+        value[std::move(key)] = std::move(item);
+        return true;
+      }
+  );
+}
+
+template <typename T>
+bool json_decode_r(
+    const char*& input,
+    std::map<std::string, T>& value,
+    adl_tag tag
+) {
+  return json_decode_r_map<std::map<std::string, T>, T>(input, value, tag);
+}
+
+template <typename T>
+bool json_decode_r(
+    const char*& input,
+    std::unordered_map<std::string, T>& value,
+    adl_tag tag
+) {
+  return json_decode_r_map<std::unordered_map<std::string, T>, T>(
+      input, value, tag
+  );
 }
 
 } // ToolFramework

--- a/src/Store/Store.cpp
+++ b/src/Store/Store.cpp
@@ -124,6 +124,10 @@ value_read:
   }
 
   bool Store::JsonParser(const char* input) {
+    if (!json_valid(input)) return false; // invalid JSON string
+
+    // We have validated input, so in the following `return false` should never
+    // happen. We keep it, however, just in case.
     bool result = json_decode_object(
         input,
         [this](const char*& input_, std::string key) -> bool {
@@ -165,8 +169,6 @@ value_read:
     );
     if (!result) return false;
 
-    input = json_scan_whitespace(input);
-    if (!input || *input) return false; // junk at the end
     return true;
   };
   

--- a/src/Store/Store.h
+++ b/src/Store/Store.h
@@ -6,7 +6,9 @@
 #include <vector>
 #include <map>
 #include <iostream>
-#include <sstream> 
+#include <sstream>
+
+#include "Json.h"
 
 namespace ToolFramework{
 
@@ -26,7 +28,8 @@ namespace ToolFramework{
     Store(); ////< Sinple constructor
     
     bool Initialise(std::string filename); ///< Initialises Store by reading in entries from an ASCII text file, when each line is a variable and its value in key value pairs.  @param filename The filepath and name to the input file.
-    void JsonParser(std::string input); ///<  Converts a flat JSON formatted string to Store entries in the form of key value pairs.  @param input The input flat JSON string.
+    bool JsonParser(const char* input);
+    bool JsonParser(const std::string& input); ///<  Converts a flat JSON formatted string to Store entries in the form of key value pairs.  @param input The input flat JSON string.
     void Print(); ///< Prints the contents of the Store.
     void Delete(); ///< Deletes all entries in the Store.
     bool Has(std::string key); ///<Returns bool based on if store contains entry given by sting @param string key to comapre.
@@ -35,160 +38,42 @@ namespace ToolFramework{
     bool Erase(std::string key);
     
     /**
-       Templated getter function for sore content. Assignment is templated and via reference.
-       @param name The ASCII key that the variable in the Store is stored with.
-       @param out The variable to fill with the value.
-       @return Return value is true if varaible exists in the Store and correctly assigned to out and false if not.
-    */
-    template<typename T> bool Get(std::string name,T &out){
-      
-      if(m_variables.count(name)>0){
-	
-	std::stringstream stream(StringStrip(m_variables[name]));
-	stream>>out;
-	return !stream.fail();
-      }
-      
-      return false;
-      
-    }
-
-    /**
-       Templated getter function for sore vector/array content. Assignment is templated and via reference.
-       @param name The ASCII key that the variable in the Store is stored with.
-       @param out The variable to fill with the value.
-       @return Return value is true if varaible exists in the Store and correctly assigned to out and false if not.
-    */
-    template<typename T> bool Get(std::string name,std::vector<T> &out){
-
-      std::string stripped = StringStrip(m_variables[name]);
-
-      if(m_variables.count(name)>0 && stripped[0]=='['){
-	std::stringstream stream;
-	out.clear();
-	  
-	for(unsigned int i=1; i<stripped.length(); i++){
-	  if(stripped[i]!=',' && stripped[i]!=']'){
-	    if(stripped[i]!='"') stream.put(stripped[i]);
-	  }
-	  else {
-	    T tmp;
-	    stream>>tmp;
-	    if(stream.fail()){
-	      out.clear();
-	      return false;
-	    }
-	    stream.str("");
-	    stream.clear();
-	    out.push_back(tmp);
-	  }
-	  
-	}
-	return true;
-	
-      }
-      
-      return false;
-      
-    }
-    
-    /**
-       getter function for string content..
-       @param name The ASCII key that the variable in the Store is stored with.
-       @param out The variable to fill with the value.
-       @return Return value is true if varaible exists in the Store and correctly assigned to out and false if not.
-    */
-    bool Get(std::string name, std::string &out);
-
-        /**
-       getter function for bool content..
-       @param name The ASCII key that the variable in the Store is stored with.
-       @param out The variable to fill with the value.
-       @return Return value is true if varaible exists in the Store and correctly assigned to out and false if not.
-    */
-    bool Get(std::string name, bool &out);
-
-        /**
-       getter function for store content..
-       @param name The ASCII key that the variable in the Store is stored with.
-       @param out The variable to fill with the value.
-       @return Return value is true if varaible exists in the Store and correctly assigned to out and false if not.
-    */
-    bool Get(std::string name, Store &out);
-
-    
-    /**
        Templated getter function for store content. 
        @param name The ASCII key that the variable in the Store is stored with.
        @return Return value is default copiler costructed value if not true (note: no checking exists)
     */
     template<typename T> T Get(std::string name){
       
-      T tmp;
+      T tmp {};
       if(!Get(name,tmp)) std::cout<<"\033[38;5;196mERROR: Store doesnt hold value \""<<name<<"\" default returned\033[0m"<<std::endl;
       
       return tmp;
       
     }
-
-    
     
     /**
-       Templated setter function to assign vairables in the Store.
-       @param name The key to be used to store and reference the variable in the Store.
-       @param in the varaible to be stored.
+       Get a value from Store and put it into out.
+       @param name The key name.
+       @param out Variable to assign the value to.
+       @return false if the key does not exit or the value could not be deserialized to this type. In the latter case, out may or may not be changed.
     */
-    template<typename T> void Set(std::string name,T in){
-      std::stringstream stream;
-      stream<<in;
-      m_variables[name]=stream.str();
-    }
+    template <typename T>
+    bool Get(const std::string& name, T& out) const {
+      auto i = m_variables.find(name);
+      if (i == m_variables.end()) return false;
+      return deserialize(i->second, out);
+    };
 
     /**
-       string setter function to assign vairables in the Store.
-       @param name The key to be used to store and reference the variable in the Store.
-       @param in the varaible to be stored.
+       Assign a value to a key.
+       @param name The key name.
+       @param value The value.
     */
+    template <typename T>
+    void Set(const std::string& name, const T& value) {
+      m_variables[name] = serialize(value);
+    };
 
-    void Set(std::string name, std::string in);
-
-    /**
-       string setter function to assign vairables in the Store.
-       @param name The key to be used to store and reference the variable in the Store.
-       @param in the varaible to be stored.
-    */
-
-    void Set(std::string name, const char* in);
-
-    /**
-       Templated setter function to assign vairables in the Store from a vector.
-       @param name The key to be used to store and reference the variable in the Store.
-       @param in the varaible to be stored.
-    */
-    
-    template<typename T> void Set(std::string name,std::vector<T> in){
-     
-      std::stringstream stream;
-      std::string tmp="[";
-      for(unsigned int i=0; i<in.size(); i++){
-	stream<<in.at(i);
-	tmp+=stream.str();
-	if(i!=in.size()-1)tmp+=',';
-	stream.str("");
-	stream.clear();	
-      }
-      tmp+=']';
-      m_variables[name]=tmp;
-      
-    }
-
-    /**
-       string setter function to assign vairables in the Store from a vector.
-       @param name The key to be used to store and reference the variable in the Store.
-       @param in the varaible to be stored.
-    */
-    
-    void Set(std::string name,std::vector<std::string> in);
     /**
        Returns string pointer to Store element.
        @param key The key of the string pointer to return.
@@ -201,37 +86,179 @@ namespace ToolFramework{
     /**
        Allows streaming of a flat JASON formatted string of Store contents.
     */
-    template<typename T> void operator>>(T& obj){
-
-      std::stringstream stream;
-      stream<<"{";
-      bool first=true;
-      for (std::map<std::string,std::string>::iterator it=m_variables.begin(); it!=m_variables.end(); ++it){
-	if (!first) stream<<", ";
-	stream<<"\""<<it->first<<"\":"<< it->second;
-	
-	first=false;
-      }
-      stream<<"}";
-      
-      obj=stream.str();
-      
-    } 
-    
-    friend std::ostream& operator<<(std::ostream &stream, const Store &s);
+    void operator>>(std::string&) const;
     
     std::map<std::string, std::string>::iterator begin() { return m_variables.begin(); }
     std::map<std::string, std::string>::iterator end()   { return m_variables.end(); }
     
+    std::map<std::string, std::string>::const_iterator begin() const { return m_variables.begin(); };
+    std::map<std::string, std::string>::const_iterator end()   const { return m_variables.end();   };
+
+    std::map<std::string, std::string>::const_iterator cbegin() const { return m_variables.cbegin(); };
+    std::map<std::string, std::string>::const_iterator cend()   const { return m_variables.cend();   };
+    
     
   private:
-    
+
+    template <typename, typename = int>
+    struct json_encode_exists : std::false_type {};
+
+    template <typename T>
+    struct json_encode_exists<
+      T,
+      decltype(
+          json_encode_r(
+            std::declval<std::ostream&>(),
+            std::declval<T>(),
+            std::declval<adl_tag>()
+          ),
+          0
+      )
+    > : std::true_type {};
+
+    template <typename, typename = int>
+    struct json_decode_exists : std::false_type {};
+
+    template <typename T>
+    struct json_decode_exists<
+      T,
+      decltype(
+          json_decode_r(
+            std::declval<const char*&>(),
+            std::declval<T&>(),
+            std::declval<adl_tag>()
+          ),
+          0
+      )
+    > : std::true_type {};
     
     std::map<std::string,std::string> m_variables;
     std::string StringStrip(std::string in);
-    
+
+    template <typename T>
+    static
+    typename std::enable_if<!json_decode_exists<T>::value, bool>::type
+    deserialize(const std::string& value, T& out) {
+      char c = 0;
+      if (!value.empty()) {
+        c = value[0];
+        if (c == '[' || c == '{') return false;
+      };
+
+      std::stringstream ss;
+      if (c == '"')
+        ss.str(value.substr(1, value.size() - 2));
+      else
+        ss.str(value);
+
+      ss >> out;
+      return !ss.fail();
+    }
+
+    template <typename T>
+    static
+    typename std::enable_if<json_decode_exists<T>::value, bool>::type
+    deserialize(const std::string& value, T& out) {
+      const char* s = value.c_str();
+      return json_decode(s, out);
+    }
+
+    template <typename T>
+    static bool deserialize(const std::string& value, std::vector<T>& out) {
+      if (value.empty() || value[0] != '[') return false;
+      const char* v = value.c_str();
+      return json_decode(v, out);
+    }
+
+    static bool deserialize(const std::string& value, std::string& out) {
+      char c = value.empty() ? 0 : value[0];
+      if (c == '{' || c == '[') return false;
+      if (c == '"')
+        out.assign(value.begin() + 1, value.end() - 1);
+      else
+        out = value;
+      return true;
+    }
+
+    static bool deserialize(const std::string& value, char& out) {
+      if (value.empty()) return false;
+      switch (value[0]) {
+        case '[':
+        case '{':
+          return false;
+        case '"':
+          if (value.size() < 2) return false;
+          out = value[1];
+          break;
+        default:
+          out = value[0];
+      };
+      return true;
+    }
+
+    static bool deserialize(const std::string& value, Store& out) {
+      if (value.empty() || value[0] != '{') return false;
+      // out.m_variables.clear() ?
+      return out.JsonParser(value);
+    }
+
+    template <typename T>
+    static
+    typename std::enable_if<!json_encode_exists<T>::value, std::string>::type
+    serialize(const T& value) {
+      std::stringstream ss;
+      ss << value;
+      std::string result = ss.str();
+      if (result.empty()) return result;
+      char r = result[0];
+      if (r == '"' || r == '[' || r == '{')
+        json_encode(result, ss.str());
+      return result;
+    }
+
+    template <typename T>
+    static
+    typename std::enable_if<json_encode_exists<T>::value, std::string>::type
+    serialize(const T& value) {
+      std::string result;
+      json_encode(result, value);
+      return result;
+    }
+
+    template <typename T>
+    static std::string serialize(const std::vector<T>& value) {
+      std::string result;
+      json_encode(result, value);
+      return result;
+    }
+
+    static std::string serialize(const char* value) {
+      std::stringstream ss;
+      ss << '"' << value << '"';
+      return ss.str();
+    }
+
+    static std::string serialize(const std::string& value) {
+      return serialize(value.c_str());
+    }
+
+    static std::string serialize(char value) {
+      if (value == '"') return "\"\\\"\"";
+      if (value == '[') return "\"[\"";
+      if (value == '{') return "\"{\"";
+      return std::string(1, value);
+    }
+
+    static std::string serialize(const Store& value) {
+      std::string result;
+      value >> result;
+      return result;
+    }
+
   };
-  
+
+  std::ostream& operator<<(std::ostream&, const Store&);
+
 } // end ToolFramework namespace
   
 

--- a/src/Store/Store.h
+++ b/src/Store/Store.h
@@ -27,7 +27,7 @@ namespace ToolFramework{
     
     Store(); ////< Sinple constructor
     
-    bool Initialise(std::string filename); ///< Initialises Store by reading in entries from an ASCII text file, when each line is a variable and its value in key value pairs.  @param filename The filepath and name to the input file.
+    bool Initialise(const std::string& filename); ///< Initialises Store by reading in entries from an ASCII text file, when each line is a variable and its value in key value pairs.  @param filename The filepath and name to the input file.
     bool JsonParser(const char* input);
     bool JsonParser(const std::string& input); ///<  Converts a flat JSON formatted string to Store entries in the form of key value pairs.  @param input The input flat JSON string.
     void Print(); ///< Prints the contents of the Store.


### PR DESCRIPTION
This pull request makes an overhaul of `Store` implementation, extending its support of edge cases in user data.

The primary change is that the structured data stored in a `Store` such as vectors and maps, are stored as JSON arrays and objects, with the strings in keys and values properly encoded, so a `"q } w"` should result the same string when requested, and it won't confuse the JSON parser and serializer.

The type of an object stored is encoded by the first character of its serialized string: `"` means that it's a string, `[` --- a vector, `{` --- a map. Any other character means that it is an object with custom encoding (see below). Strings and custom objects are stored as is, but when serialized to JSON format, their contents are properly escaped to produce a valid JSON string. Vectors and maps are stored in JSON format initially.

The user can add support for storage of their own classes `T` by implementing `operator<<(std::ostream&, T)` and `operator>>(std::istream&, T&)`, or `json_encode_r(std::ostream&, T)` and `json_decode_r(const char*&, T&)`. When both the operators and the functions are defined, the functions take priority. `json_encode_r` and `json_decode_r` extend the JSON parser and serializer to support custom user classes and are useful outside the `Store` class.

Speaking of JSON, this pull request also adds generic functions for JSON production, validation, and parsing, see `json_encode`, `json_scan*` and `json_decode` in `Json.h`.

`Store::Initialise` has been updated to allow escaped comments, newlines, and spaces at the end of a line, and to keep all of the spaces in the value string, so

    var long   space \# test \\ \
      newline  \ 

results in `"long   space # test \\ \n newline   "`. This change is not backwards compatible, but it is unlikely that anyone relied on that feature.

`UnitTests/StoreTest` has been rewritten to test for many edge cases and the new features.

I personally think that we should stop abusing `Store` for JSON data and instead either implement a custom `JSON` object that stores values as a tree in memory, or just use the new `json_encode` and `json_decode` functions for (de-)serialization.

I have checked that libDAQInterface Example works with the new `Store`, but I think is worth testing this code on some real codebase before merging this pull request. Can someone do that?

This pull request fixes #19, #22, #25. #16 appears to be not relevant anymore.